### PR TITLE
chore: group dependabot updates and add 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,24 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
+    groups:
+      aspire:
+        patterns:
+          - "Aspire*"
+      orleans:
+        patterns:
+          - "Microsoft.Orleans.*"
+      microsoft-extensions:
+        patterns:
+          - "Microsoft.Extensions.*"
+      opentelemetry:
+        patterns:
+          - "OpenTelemetry.*"
+      test:
+        patterns:
+          - "xunit*"
+          - "coverlet*"
+          - "Microsoft.NET.Test.Sdk"
+          - "GitHubActionsTestLogger"


### PR DESCRIPTION
## Summary
- Adds five Dependabot groups (`aspire`, `orleans`, `microsoft-extensions`, `opentelemetry`, `test`) so related NuGet updates land in a single PR per family instead of one PR per package.
- Adds a 7-day `cooldown` so Dependabot waits a week after a new version ships before opening an update PR, reducing churn from same-day patch releases.
- Motivation: recent bursts of individual Aspire bumps (#44, #46, #49, #50, #51, #52) created CodeQL baseline race conditions on `main` and noisy review surface.

## Group coverage
| Group | Pattern | Catches |
|---|---|---|
| `aspire` | `Aspire*` | Aspire.Azure.Data.Tables, Aspire.Azure.Storage.Blobs, Aspire.Hosting.AppHost, Aspire.Hosting.Azure.Storage, Aspire.Hosting.Orleans |
| `orleans` | `Microsoft.Orleans.*` | All 9 Microsoft.Orleans.* packages currently pinned to 10.1.0 |
| `microsoft-extensions` | `Microsoft.Extensions.*` | Hosting, Telemetry, Telemetry.Abstractions, Http.Resilience, ServiceDiscovery |
| `opentelemetry` | `OpenTelemetry.*` | Exporter.* and Instrumentation.* packages |
| `test` | `xunit*`, `coverlet*`, `Microsoft.NET.Test.Sdk`, `GitHubActionsTestLogger` | Test-only deps in Agave.Tests |

`MinVer` intentionally left ungrouped (build-only tool, isolated upgrades safer).